### PR TITLE
Prevent memory leak from self-owning shared_ptr

### DIFF
--- a/include/cxxeffect/stream.hpp
+++ b/include/cxxeffect/stream.hpp
@@ -132,8 +132,9 @@ namespace eff {
                         pull<F, O, top> tl = p.second;
 
                         std::shared_ptr<std::function<pull<F, P, top> (std::size_t)>> go = std::make_shared<std::function<pull<F, P, top> (std::size_t)>>();
-                        *go = [*this, hd, tl, go](std::size_t idx) {
+                        *go = [*this, hd, tl, go](std::size_t idx) mutable {
                             if(idx == hd.size()) {
+                                go.reset();
                                 return tl.flatMapOutput(f);
                             } else {
                                 std::function<pull<F, P, top> (std::size_t)> goI = *go;


### PR DESCRIPTION
go is captured by a lambda closure, but it is also owns that closure. In other words it references itself. Thus on the final loop, reset go to null. This requires making the lambda mutable.

This will still leak if the loop doesn't run to completion.